### PR TITLE
Change FeatureEngineer init type hinting

### DIFF
--- a/metaflow_helper/feature_engineer.py
+++ b/metaflow_helper/feature_engineer.py
@@ -3,8 +3,8 @@ from sklearn.pipeline import Pipeline
 
 
 class FeatureEngineer:
-    def __init__(self, pipeline_fn: Callable, **kwargs):
-        self.pipeline: Pipeline = pipeline_fn(**kwargs)
+    def __init__(self, pipeline_fn: Callable[..., Pipeline], **kwargs):
+        self.pipeline = pipeline_fn(**kwargs)
         if not isinstance(self.pipeline, Pipeline):
             raise ValueError(f'pipeline_fn must return an instance of sklearn.pipeline.Pipeline, was {type(self.pipeline)}')
 


### PR DESCRIPTION
I'm enjoying your blog posts on Metaflow. I started looking around this code and saw a small hinting change you might like.

I changed the Callable hint to include the return value. [docs](https://docs.python.org/3.6/library/typing.html#typing.Callable). The ellipses means that the Callable can accept any arguments.

The benefit of doing it this way is you get the type hint on construction _and_ on the attribute. Doing just an attribute hint will only cover the attribute.

Here's a screenshot of an example in PyCharm, using `int` instead of `Pipeline`. You can see on line 10 there's no warning, even though IntWrapperA is taking a function that returns a string. On line 19, you have the warning. And the hinting on the integer attribute still works.

<img width="829" alt="Screen Shot 2021-06-12 at 12 33 06 PM" src="https://user-images.githubusercontent.com/11671107/121784591-59ebb400-cb7a-11eb-92a0-b58d9819a7cb.png">

This won't affect runtime validation, so that's left unchanged.

